### PR TITLE
Define navbar height in stylesheets.

### DIFF
--- a/app/scss/nav.scss
+++ b/app/scss/nav.scss
@@ -2,6 +2,7 @@
 
 .navbar-sse {
   background-color: $PRIMARY;
+  height: 79px;
 
   .nav-item .nav-link {
     padding: 0 12px;


### PR DESCRIPTION
The navbar image is larger than the default navbar height. When the image loads in the navbar expands suddenly. 

This change defines the height in the styles so that it is the correct height on initial load.