### PR TITLE
Change navbar height to min-height.

### DIFF
--- a/app/scss/nav.scss
+++ b/app/scss/nav.scss
@@ -2,7 +2,7 @@
 
 .navbar-sse {
   background-color: $PRIMARY;
-  height: 79px;
+  min-height: 79px;
 
   .nav-item .nav-link {
     padding: 0 12px;


### PR DESCRIPTION
The mobile nav was broken when the navbar height was specified. This changes it to min-height so it will expand as needed.