### PR TITLE
AddMembership default committee

### DIFF
--- a/app/js/scoreboard/components/AddMembershipModal.jsx
+++ b/app/js/scoreboard/components/AddMembershipModal.jsx
@@ -41,7 +41,7 @@ class AddMembershipModal extends Component {
             startDate: moment().format(dayFormat),
             endDate: '',
             reason: '',
-            committeeName: initialCommitteeName.committeeName || '',
+            committeeName: initialCommitteeName,
           }}
           validationSchema={yup.object()
             .shape({

--- a/app/js/scoreboard/components/AddMembershipModal.jsx
+++ b/app/js/scoreboard/components/AddMembershipModal.jsx
@@ -14,6 +14,7 @@ class AddMembershipModal extends Component {
     isOpen: PropTypes.bool.isRequired,
     close: PropTypes.func.isRequired,
     create: PropTypes.func.isRequired,
+    initialCommitteeName: PropTypes.string.isRequired,
   };
 
   componentDidMount() {
@@ -26,6 +27,7 @@ class AddMembershipModal extends Component {
       isOpen,
       close,
       create,
+      initialCommitteeName,
     } = this.props;
 
     const committeeNames = committees.map(committee => committee.name);
@@ -39,7 +41,7 @@ class AddMembershipModal extends Component {
             startDate: moment().format(dayFormat),
             endDate: '',
             reason: '',
-            committeeName: 'Historians', // Historians usually enter the most memberships (b/c photo submissions)
+            committeeName: initialCommitteeName.committeeName || '',
           }}
           validationSchema={yup.object()
             .shape({

--- a/app/js/scoreboard/containers/AddMembershipModal.js
+++ b/app/js/scoreboard/containers/AddMembershipModal.js
@@ -7,7 +7,7 @@ function mapStateToProps(store) {
   return {
     isOpen: store.modal.modalType === ADD_MEMBERSHIP_MODAL,
     committees: store.committees,
-    initialCommitteeName: store.auth.officer || '',
+    initialCommitteeName: store.auth.officer ? store.auth.officer.committeeName : '',
   };
 }
 

--- a/app/js/scoreboard/containers/AddMembershipModal.js
+++ b/app/js/scoreboard/containers/AddMembershipModal.js
@@ -7,6 +7,7 @@ function mapStateToProps(store) {
   return {
     isOpen: store.modal.modalType === ADD_MEMBERSHIP_MODAL,
     committees: store.committees,
+    initialCommitteeName: store.auth.officer || '',
   };
 }
 


### PR DESCRIPTION
When creating a new membership, the form field for "Committee Name" defaults to the committee the officer logged in belongs to

Closes #173 