### PR TITLE
Fix Forms in Prod

### DIFF
--- a/app/js/common/components/UserForm.jsx
+++ b/app/js/common/components/UserForm.jsx
@@ -75,6 +75,7 @@ class UserForm extends Component {
         ) => {
           // Proxy the values because we don't know how any additional fields will need to be handled
           onSubmit({
+            ...values,
             dce: values.dce.toLowerCase(),
             // On these optional fields, the API expects 'null' instead of empty string ('')
             firstName: values.firstName || null,


### PR DESCRIPTION
Due to changes in #175 and then upstream changes to prod in #176, forms dependent on `<UserForm/>` broke because not all required values were proxied properly, therefore causing db validations to fail.

Closes #177 