### PR TITLE
Add tabs to the memberships table, which hides officer memberships to manage clutter

### DIFF
--- a/app/js/scoreboard/components/Member.jsx
+++ b/app/js/scoreboard/components/Member.jsx
@@ -43,14 +43,14 @@ const Member = ({
   viewItem,
 }) => (
   <Row onClick={viewItem} className="member" index={index}>
-    <td>{index}</td>
+    <td style={{ width: '15%' }}>{index}</td>
     <td>
       <img src={gravatar(dce)} alt="Member" className="gravatar" />
       <div className="name">
         {name}
       </div>
     </td>
-    <td>{count}</td>
+    <td style={{ width: '15%' }}>{count}</td>
   </Row>
 );
 

--- a/app/js/scoreboard/components/MembershipList.jsx
+++ b/app/js/scoreboard/components/MembershipList.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 import MemberList from 'scoreboard/containers/MembersList';
 
-export default class MembershipList extends Component {
+class MembershipList extends Component {
   constructor(props) {
     super(props);
 
@@ -54,3 +54,5 @@ export default class MembershipList extends Component {
     );
   }
 }
+
+export default MembershipList;

--- a/app/js/scoreboard/components/MembershipList.jsx
+++ b/app/js/scoreboard/components/MembershipList.jsx
@@ -2,12 +2,15 @@ import React, { Component } from 'react';
 
 import MemberList from 'scoreboard/containers/MembersList';
 
+const MEMBERS = 'MEMBERS';
+const OFFICERS = 'OFFICERS';
+
 class MembershipList extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      displaying: 'MEMBERS',
+      displaying: MEMBERS,
     };
   }
 
@@ -22,8 +25,8 @@ class MembershipList extends Component {
           <li className="nav-item">
             <span
               style={{ cursor: 'pointer' }}
-              className={`nav-link ${displaying === 'MEMBERS' ? 'active' : ''}`}
-              onClick={() => this.setState({ displaying: 'MEMBERS' })}
+              className={`nav-link ${displaying === MEMBERS ? 'active' : ''}`}
+              onClick={() => this.setState({ displaying: MEMBERS })}
               role="tab"
             >
                 Members
@@ -32,8 +35,8 @@ class MembershipList extends Component {
           <li className="nav-item">
             <span
               style={{ cursor: 'pointer' }}
-              className={`nav-link ${displaying === 'OFFICERS' ? 'active' : ''}`}
-              onClick={() => this.setState({ displaying: 'OFFICERS' })}
+              className={`nav-link ${displaying === OFFICERS ? 'active' : ''}`}
+              onClick={() => this.setState({ displaying: OFFICERS })}
               role="tab"
             >
               Officers
@@ -44,7 +47,7 @@ class MembershipList extends Component {
           <thead>
             <tr>
               <th>#</th>
-              <th>{displaying === 'MEMBERS' ? 'Member' : 'Officer'}</th>
+              <th>{displaying === MEMBERS ? 'Member' : 'Officer'}</th>
               <th>Score</th>
             </tr>
           </thead>

--- a/app/js/scoreboard/components/MembershipList.jsx
+++ b/app/js/scoreboard/components/MembershipList.jsx
@@ -1,19 +1,51 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import MemberList from 'scoreboard/containers/MembersList';
 
-const MembershipList = () => (
-  <div className="offset-sm-1 col-sm-10 offset-md-2 col-md-8">
-    <table className="table" style={{ border: '1px solid #dee2e6' }}>
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Member</th>
-          <th>Score</th>
-        </tr>
-      </thead>
-      <MemberList wrapper="tbody" />
-    </table>
-  </div>
-);
 
-export default MembershipList;
+export default class MembershipList extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      displayedType: 'MEMBERS',
+    };
+  }
+
+  render() {
+    const displaying = this.state.displayedType;
+    return (
+      <div className="offset-sm-1 col-sm-10 offset-md-2 col-md-8">
+        <ul className="nav nav-tabs">
+          <li className="nav-item">
+            <span
+              style={{ cursor: 'pointer' }}
+              className={`nav-link ${displaying === 'MEMBERS' ? 'active' : ''}`}
+              onClick={() => this.setState({ displayedType: 'MEMBERS' })}
+            >
+                Members
+            </span>
+          </li>
+          <li className="nav-item">
+            <span
+              style={{ cursor: 'pointer' }}
+              className={`nav-link ${displaying === 'OFFICERS' ? 'active' : ''}`}
+              onClick={() => this.setState({ displayedType: 'OFFICERS' })}
+            >
+              Officers
+            </span>
+          </li>
+        </ul>
+        <table className="table" style={{ border: '1px solid #dee2e6' }}>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Member</th>
+              <th>Score</th>
+            </tr>
+          </thead>
+          <MemberList wrapper="tbody" displayedType={displaying} />
+        </table>
+      </div>
+    );
+  }
+}

--- a/app/js/scoreboard/components/MembershipList.jsx
+++ b/app/js/scoreboard/components/MembershipList.jsx
@@ -1,18 +1,21 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import MemberList from 'scoreboard/containers/MembersList';
 
+import MemberList from 'scoreboard/containers/MembersList';
 
 export default class MembershipList extends Component {
   constructor(props) {
     super(props);
+
     this.state = {
-      displayedType: 'MEMBERS',
+      displaying: 'MEMBERS',
     };
   }
 
   render() {
-    const displaying = this.state.displayedType;
+    const {
+      displaying,
+    } = this.state;
+
     return (
       <div className="offset-sm-1 col-sm-10 offset-md-2 col-md-8">
         <ul className="nav nav-tabs">
@@ -20,7 +23,8 @@ export default class MembershipList extends Component {
             <span
               style={{ cursor: 'pointer' }}
               className={`nav-link ${displaying === 'MEMBERS' ? 'active' : ''}`}
-              onClick={() => this.setState({ displayedType: 'MEMBERS' })}
+              onClick={() => this.setState({ displaying: 'MEMBERS' })}
+              role="tab"
             >
                 Members
             </span>
@@ -29,7 +33,8 @@ export default class MembershipList extends Component {
             <span
               style={{ cursor: 'pointer' }}
               className={`nav-link ${displaying === 'OFFICERS' ? 'active' : ''}`}
-              onClick={() => this.setState({ displayedType: 'OFFICERS' })}
+              onClick={() => this.setState({ displaying: 'OFFICERS' })}
+              role="tab"
             >
               Officers
             </span>
@@ -39,11 +44,11 @@ export default class MembershipList extends Component {
           <thead>
             <tr>
               <th>#</th>
-              <th>Member</th>
+              <th>{displaying === 'MEMBERS' ? 'Member' : 'Officer'}</th>
               <th>Score</th>
             </tr>
           </thead>
-          <MemberList wrapper="tbody" displayedType={displaying} />
+          <MemberList wrapper="tbody" displaying={displaying} />
         </table>
       </div>
     );

--- a/app/js/scoreboard/containers/MembersList.js
+++ b/app/js/scoreboard/containers/MembersList.js
@@ -6,7 +6,7 @@ import { getMembers } from 'scoreboard/actions';
 import { getOfficers } from 'officers/actions';
 
 function mapStateToProps(store, { displaying }) {
-  // Make a list of all the officers' dce's (eg. [abc124, xyz9876])
+  // Make a list of all the officers' dce's (eg. [abc1234, xyz9876])
   const officerDces = Object.values(store.officers).map(officer => officer.userDce);
   return {
     item: Member,

--- a/app/js/scoreboard/containers/MembersList.js
+++ b/app/js/scoreboard/containers/MembersList.js
@@ -3,12 +3,15 @@ import { viewMembershipModal } from 'common/actions';
 import List from 'common/components/List';
 import Member from 'scoreboard/components/Member';
 import { getMembers } from 'scoreboard/actions';
+import { getOfficers } from 'officers/actions';
 
-function mapStateToProps(store) {
+function mapStateToProps(store, { displayedType }) {
+  const officerDces = Object.values(store.officers).map(officer => officer.userDce);
   return {
     item: Member,
     items: Object
       .keys(store.members)
+      .filter(dce => (displayedType === 'MEMBERS' ? !officerDces.includes(dce) : officerDces.includes(dce)))
       .sort((a, b) => store.members[b].count - store.members[a].count)
       .map((el, index) => ({
         ...store.members[el],
@@ -20,7 +23,10 @@ function mapStateToProps(store) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    getItems: () => dispatch(getMembers()),
+    getItems: () => {
+      dispatch(getMembers());
+      dispatch(getOfficers());
+    },
     viewItem: id => dispatch(viewMembershipModal(id)),
   };
 }

--- a/app/js/scoreboard/containers/MembersList.js
+++ b/app/js/scoreboard/containers/MembersList.js
@@ -5,13 +5,18 @@ import Member from 'scoreboard/components/Member';
 import { getMembers } from 'scoreboard/actions';
 import { getOfficers } from 'officers/actions';
 
-function mapStateToProps(store, { displayedType }) {
+function mapStateToProps(store, { displaying }) {
+  // Make a list of all the officers' dce's (eg. [abc124, xyz9876])
   const officerDces = Object.values(store.officers).map(officer => officer.userDce);
   return {
     item: Member,
     items: Object
+      // Iterate over all members. Their key is their dce.
       .keys(store.members)
-      .filter(dce => (displayedType === 'MEMBERS' ? !officerDces.includes(dce) : officerDces.includes(dce)))
+      // If we're displaying the officers table, filter out the officers / don't include members.
+      // If we're displaying the members table, filter out the members / don't include officers.
+      .filter(dce => (displaying === 'OFFICERS' ? officerDces.includes(dce) : !officerDces.includes(dce)))
+      // Sort by number of memberships (highest first)
       .sort((a, b) => store.members[b].count - store.members[a].count)
       .map((el, index) => ({
         ...store.members[el],

--- a/app/js/scoreboard/index.js
+++ b/app/js/scoreboard/index.js
@@ -1,9 +1,11 @@
 import { injectAsyncReducer } from 'store';
+import officers from 'officers/reducers';
 
 import Page from './Page';
 import { memberships, members } from './reducers';
 
 injectAsyncReducer('members', members);
 injectAsyncReducer('memberships', memberships);
+injectAsyncReducer('officers', officers);
 
 export default Page;


### PR DESCRIPTION
Adds tabs (via react props) to toggle between viewing "Member" memberships vs "Officers" memberships, to hide overachieving officers and avoid clutter.

Closes #179 