### PR TITLE
Add download icon for calendar events.

### DIFF
--- a/app/js/events/Page.jsx
+++ b/app/js/events/Page.jsx
@@ -4,6 +4,7 @@ import CreateButton from 'common/containers/CreateButton';
 import { showEventModal, COMMITTEES } from 'common/actions';
 import Status from 'common/containers/Status';
 import Login from 'common/containers/Login';
+import Button from 'common/components/Button';
 import CommitteesList from 'events/containers/CommitteesList';
 import EventModal from 'events/containers/EventModal';
 import EventList from 'events/containers/EventList';
@@ -17,12 +18,18 @@ const Event = () => (
         <Link to="/events" className="title-link">
           <h2 className="pull-left">Events</h2>
         </Link>
+
         <div className="btn-group pb-2 mt-sm-1 float-right" role="group" aria-label="Basic example">
           <CreateButton action={showEventModal} className="btn btn-secondary" >
             Create
           </CreateButton>
           <Login className="btn btn-sse" />
         </div>
+        <Link to="/api/v2/events.ics" className="float-right" style={{marginTop: "4px", marginRight: "4px"}}>
+            <Button className="btn btn-sse">
+                <i className="fa fa-calendar" aria-hidden="true" alt="Import Calendar" title="Import Calendar" />
+            </Button>
+        </Link>
       </div>
     </div>
     <div className="row">


### PR DESCRIPTION
Issue #214 

<img width="952" alt="image" src="https://user-images.githubusercontent.com/6372519/46223025-1c8a5e00-c320-11e8-93e5-1054a8d973a5.png">

For some reason the link doesn't do anything in local dev, maybe since there are no events, but works fine in dev and prod.