### PR TITLE
Fix Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN chmod 755 -R /app/dist
 
 # Run nginx
 EXPOSE 80 443
-CMD ["nginx", "-g", "daemon off"]
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Add Semicolon Back

Removed in #222, but it's needed otherwise nginx errors.