### PR TITLE
Update governing docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ If you're only making visual changes, you can skip installing the node-api and u
 
 However, if you're making changes to authenticated pages (eg. event creation, go link creation, approving scoreboard memberships) or making data model / database changes, you'll have to install and setup the node-api. Then you'll set your `API_ROOT` where your local installation is running (eg. `API_ROOT=localhost:3000/api/v2/ npm start`).
 
+If you need to update the [governing-docs](https://github.com/rit-sse/governing-docs), you will need to update it as a git submodule from the top level of the this repo. To update the governing-docs submodule, make sure you have the submodule checked out by running
+`git submodule update --init --recursive` at the top level of this repo
+then `cd` into the governing-docs folder and run `git pull origin master`. More information can be found at this [pull request](https://github.com/rit-sse/OneRepoToRuleThemAll/pull/240).
+
 ## Deployment
 
 We have CircleCI and Docker Hub setup so `devlop` will deploy to `ssedev.se.rit.edu` and `master` will deploy to `sse.rit.edu`.


### PR DESCRIPTION
This is the continuation of 
https://github.com/rit-sse/OneRepoToRuleThemAll/pull/240 after accidentally forcing pushing an empty branch, which closed the previous PR.

This correctly uses the submodule to update the governing-docs.