### PR TITLE
Scoreboard medals instead of highlighting rows

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -16,7 +16,7 @@
   <meta name="twitter:image" content="<%= htmlWebpackPlugin.options.urlRoot %><%=require('./img/sse-og.png')%>" />
   <meta property="og:description" content="The Society of Software Engineers (SSE) is a student organization at RIT composed of software engineers, computer scientists, and other students. We have over fifty active members that participate in mentoring, software projects, intramural sports, and social events. The SSE has strong relationships with companies like Microsoft, Google, Apple, Northrup Grumman, Goodrich, IBM, and Oracle. We work closely with companies in the software industry to provide our members with potential career opportunities.">
   <title><%= htmlWebpackPlugin.options.title %></title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.0/css/all.css" integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
   <script src="https://apis.google.com/js/api:client.js" async defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.23.0/polyfill.min.js"></script>

--- a/app/js/common/components/Actions.jsx
+++ b/app/js/common/components/Actions.jsx
@@ -14,10 +14,10 @@ const Actions = ({
     <div className={shown ? 'actions shown' : 'actions'}>
       {children}
       <button className="btn btn-small btn-primary" onClick={editItem}>
-        <i className="fa fa-pencil" aria-hidden="true" />
+        <i className="fas fa-pencil" aria-hidden="true" />
       </button>
       <button className="btn btn-small btn-danger" onClick={deleteItem}>
-        <i className="fa fa-trash-o" aria-hidden="true" />
+        <i className="fas fa-trash-o" aria-hidden="true" />
       </button>
     </div>
   ) : null

--- a/app/js/common/components/AsyncComponent.jsx
+++ b/app/js/common/components/AsyncComponent.jsx
@@ -32,7 +32,7 @@ export default getComponent => (
       return (
         <div className="row">
           <div className="col-12">
-            <i className="fa fa-spinner fa-3x fa-spin" style={{ margin: '0 auto', display: 'block', width: '45px' }} />
+            <i className="fas fa-spinner fa-3x fa-spin" style={{ margin: '0 auto', display: 'block', width: '45px' }} />
           </div>
         </div>
       );

--- a/app/js/common/components/Login.jsx
+++ b/app/js/common/components/Login.jsx
@@ -39,8 +39,8 @@ class Login extends Component {
 
   render() {
     return this.props.user ? (
-      <Button className={this.props.className} onClick={this.props.signOut}><i className="fa fa-sign-out" /></Button>
-    ) : <button className={this.props.className} key="loggedin" ref={(c) => { this.button = c; }}><i className="fa fa-sign-in" /> Login</button>;
+      <Button className={this.props.className} onClick={this.props.signOut}><i className="fas fa-sign-out-alt" /></Button>
+    ) : <button className={this.props.className} key="loggedin" ref={(c) => { this.button = c; }}><i className="fas fa-sign-in-alt" /> Login</button>;
   }
 }
 

--- a/app/js/common/components/Status.jsx
+++ b/app/js/common/components/Status.jsx
@@ -22,7 +22,7 @@ const Status = props => (
           <strong>{props.info}</strong>
         </div>;
       } else if (props.spinner && props.loading) {
-        <i className="fa fa-spinner fa-3x fa-spin" style={{ margin: '0 auto', display: 'block', width: '45px' }} />;
+        <i className="fas fa-spinner fa-3x fa-spin" style={{ margin: '0 auto', display: 'block', width: '45px' }} />;
       }
     }}
   </div>

--- a/app/js/events/Page.jsx
+++ b/app/js/events/Page.jsx
@@ -27,7 +27,7 @@ const Event = () => (
         </div>
         <a href="/api/v2/events.ics" rel="noopener" className="float-right" style={{marginTop: "4px", marginRight: "4px"}}>
             <Button className="btn btn-sse">
-                <i className="fa fa-calendar" aria-hidden="true" alt="Import Calendar" title="Import Calendar" />
+                <i className="fas fa-calendar-alt" aria-hidden="true" alt="Import Calendar" title="Import Calendar" />
             </Button>
         </a>
       </div>

--- a/app/js/qdb/components/PendingQuote.jsx
+++ b/app/js/qdb/components/PendingQuote.jsx
@@ -70,7 +70,7 @@ class PendingQuote extends Component {
             deleteItem={deleteItem}
           >
             <button className="btn btn-small btn-success" onClick={() => approveQuote(id)}>
-              <i className="fa fa-rocket" aria-hidden="true" />
+              <i className="fas fa-rocket" aria-hidden="true" />
             </button>
           </Actions>
         </div>

--- a/app/js/scoreboard/components/Member.jsx
+++ b/app/js/scoreboard/components/Member.jsx
@@ -13,7 +13,7 @@ const Medal = styled.i`
       case 1:
         return 'gold;';
       case 2:
-        return '#d8d6d1;'
+        return 'silver';
       case 3:
         return '#cc8062;';
       default:

--- a/app/js/scoreboard/components/Member.jsx
+++ b/app/js/scoreboard/components/Member.jsx
@@ -7,32 +7,23 @@ import { gravatar } from 'utils/images';
 
 import 'scss/member.scss';
 
-const Row = styled.tr`
-  background: ${(props) => {
+const Medal = styled.i`
+  color: ${props => {
     switch (props.index) {
       case 1:
-        return 'linear-gradient(to bottom right, #ffe84d -50%, gold, #ffe84d 150%)';
+        return 'gold;';
       case 2:
-        return 'linear-gradient(to bottom right, white -50%, #d8d6d1, white 200%)';
+        return '#d8d6d1;'
       case 3:
-        return 'linear-gradient(to bottom right, #e0964d -150%, #cc8062, #e0964d 150%)';
+        return '#cc8062;';
       default:
-        return '';
+        return 'rgba(0, 0, 0, 0);';
     }
-  }};
+  }}
+  margin: 4px; 
+`;
 
-  td {
-    border: ${(props) => {
-      switch (props.index) {
-        case 1:
-        case 2:
-        case 3:
-          return 'none';
-        default:
-          return '';
-      }
-    }};
-  }
+const Row = styled.tr`
 `;
 
 const Member = ({
@@ -45,6 +36,9 @@ const Member = ({
   <Row onClick={viewItem} className="member" index={index}>
     <td style={{ width: '15%' }}>{index}</td>
     <td>
+      <Medal index={index}>
+        <i className="fas fa-medal"></i>
+      </Medal>
       <img src={gravatar(dce)} alt="Member" className="gravatar" />
       <div className="name">
         {name}


### PR DESCRIPTION
<img width="804" alt="screen shot 2019-02-11 at 4 01 33 pm" src="https://user-images.githubusercontent.com/7254185/52593238-76df1380-2e16-11e9-8b46-4b648b5bf9b6.png">

Highlighting the whole row burns retinas, so I made this. I had to update the version of FontAwesome, which breaks some of our uses of it, so I should fix that before / if this gets merged.