### PR TITLE
Believe issue was identified and solved with this minor fix

### DIFF
--- a/app/js/go/components/GoModal.jsx
+++ b/app/js/go/components/GoModal.jsx
@@ -64,7 +64,6 @@ class GoModal extends Component {
           onSubmit={(
             values
           ) => {
-            console.log(values);
             const actualValues = { ...values, public: values.public };
             close();
 

--- a/app/js/go/containers/GoLinksList.js
+++ b/app/js/go/containers/GoLinksList.js
@@ -13,7 +13,7 @@ function mapStateToProps({ go, auth, scroll }) {
     wrapper: 'ul',
     wrapperProps: { className: 'list-group' },
     items: go.all.filter((link) => {
-      if (auth.officer !== null) {
+      if (auth.officer) {
         return true;
       }
       return link.public;


### PR DESCRIPTION
I found a console log that managed to escape onto the master branch, so I removed it. 

It was also brought to my attention that there was an issue (see below) where a non-officer could login to the site and see all of the go link's descriptions and short links (weren't able to change them or anything like that) even if they weren't public. Believe it was a false check vs a Null check issue and that this fix will work but I can't test the change since I am an officer. I will have a non-officer login and check dev before this is merged into master. If this is not the fix, I will look into further, but believe this was the case.

![image](https://user-images.githubusercontent.com/32456160/54850813-8592d300-4cbe-11e9-87a8-bdcc5d4c22db.png)
