### PR TITLE
All links visible by non-officer login fix

### DIFF
--- a/app/js/go/components/GoModal.jsx
+++ b/app/js/go/components/GoModal.jsx
@@ -64,7 +64,6 @@ class GoModal extends Component {
           onSubmit={(
             values
           ) => {
-            console.log(values);
             const actualValues = { ...values, public: values.public };
             close();
 

--- a/app/js/go/containers/GoLinksList.js
+++ b/app/js/go/containers/GoLinksList.js
@@ -13,7 +13,7 @@ function mapStateToProps({ go, auth, scroll }) {
     wrapper: 'ul',
     wrapperProps: { className: 'list-group' },
     items: go.all.filter((link) => {
-      if (auth.officer !== null) {
+      if (auth.officer) {
         return true;
       }
       return link.public;


### PR DESCRIPTION
Tested locally via a roommate and issue resolved properly. Public links are the only thing visible by non-officers whether the user is logged in or not