### PR TITLE
Allow Officers to Add a LinkedIn Link to Profile

### DIFF
--- a/app/js/common/components/UserForm.jsx
+++ b/app/js/common/components/UserForm.jsx
@@ -99,8 +99,8 @@ class UserForm extends Component {
             <ModalBody>
               <fieldset className="form-group">
                 <div className="form-group row">
-                  <label htmlFor="dce" className="col-3 col-form-label">RIT Username</label>
-                  <div className="col-9">
+                  <label htmlFor="dce" className="col-4 col-form-label">RIT Username</label>
+                  <div className="col-8">
                     <input
                       type="text"
                       name="dce"
@@ -123,8 +123,8 @@ class UserForm extends Component {
                   </div>
                 </div>
                 <div className="form-group row">
-                  <label htmlFor="firstName" className="col-3 col-form-label">First Name</label>
-                  <div className="col-9">
+                  <label htmlFor="firstName" className="col-4 col-form-label">First Name</label>
+                  <div className="col-8">
                     <input
                       type="text"
                       name="firstName"
@@ -140,8 +140,8 @@ class UserForm extends Component {
                   </div>
                 </div>
                 <div className="form-group row">
-                  <label htmlFor="lastName" className="col-3 col-form-label">Last Name</label>
-                  <div className="col-9">
+                  <label htmlFor="lastName" className="col-4 col-form-label">Last Name</label>
+                  <div className="col-8">
                     <input
                       type="text"
                       name="lastName"
@@ -157,8 +157,8 @@ class UserForm extends Component {
                   </div>
                 </div>
                 <div className="form-group row">
-                  <label htmlFor="image" className="col-3 col-form-label">Image</label>
-                  <div className="col-9">
+                  <label htmlFor="image" className="col-4 col-form-label">Image</label>
+                  <div className="col-8">
                     <input
                       type="text"
                       name="image"

--- a/app/js/officers/components/Officer.jsx
+++ b/app/js/officers/components/Officer.jsx
@@ -8,6 +8,7 @@ class Officer extends Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     email: PropTypes.string.isRequired,
+    linkedinUrl: PropTypes.string,
     user: PropTypes.shape({
       firstName: PropTypes.string,
       lastname: PropTypes.string,
@@ -44,6 +45,7 @@ class Officer extends Component {
       title,
       user,
       email,
+      linkedinUrl,
       editItem,
       deleteItem,
       showActions,
@@ -54,7 +56,13 @@ class Officer extends Component {
     return (
       <SwipeArea onLeft={this.showActions} onRight={this.hideActions} className="actions-container-fade col-sm-6 col-lg-3 pb-3">
         <div className="media">
-          <img className="mr-3" src={gravatar(dce, image)} alt="Officer" height={80} />
+          {linkedinUrl ? (
+            <a href={linkedinUrl} target="_blank" rel="noopener noreferrer">
+              <img className="mr-3" src={gravatar(dce, image)} alt="Officer" height={80} />
+            </a>
+          ) : (
+            <img className="mr-3" src={gravatar(dce, image)} alt="Officer" height={80} />
+          )}
           <div className="d-flex align-self-center flex-column media-body">
             <h5 className="mb-0">{title}</h5>
             <p className="m-0">

--- a/app/js/officers/components/OfficerForm.jsx
+++ b/app/js/officers/components/OfficerForm.jsx
@@ -18,6 +18,7 @@ class OfficerForm extends Component {
       primaryOfficer: PropTypes.bool,
       startDate: PropTypes.string,
       endDate: PropTypes.string,
+      linkedinUrl: PropTypes.string,
       user: PropTypes.shape({
         firstName: PropTypes.string,
         lastName: PropTypes.string,
@@ -72,6 +73,7 @@ class OfficerForm extends Component {
             primaryOfficer: !!officer.primaryOfficer,
             startDate: officer.startDate ? moment(officer.startDate).format(dayFormat) : '',
             endDate: officer.endDate ? moment(officer.endDate).format(dayFormat) : '',
+            linkedinUrl: officer.linkedinUrl || null,
           }}
           validationSchema={yup.object()
             .shape({
@@ -95,6 +97,7 @@ class OfficerForm extends Component {
                 // value to '' for formik to use it as a controlled component, the 'isAfter'
                 // validation will be active, effectively requiring a value. We need to figure
                 // out how to have yup validate a field only if the field isn't empty (something other than '').
+              linkedinUrl: yup.string().url('Must be a URL.').nullable(),
             })}
           onSubmit={(
             values
@@ -106,6 +109,7 @@ class OfficerForm extends Component {
               primaryOfficer: values.primaryOfficer,
               startDate: moment(values.startDate).toISOString(),
               endDate: values.endDate ? moment(values.endDate).toISOString() : null,
+              linkedinUrl: values.linkedinUrl,
               user: {
                 firstName: values.firstName,
                 lastName: values.lastName,
@@ -255,6 +259,24 @@ class OfficerForm extends Component {
                   {touched.endDate
                     && errors.endDate
                     && <FormFeedback style={{ display: 'block' }}>{errors.endDate}</FormFeedback>}
+                </div>
+              </div>
+              <div className="form-group row">
+                <label htmlFor="linkedinUrl" className="col-4 col-form-label">LinkedIn URL</label>
+                <div className="col-8">
+                  <input
+                    type="text"
+                    name="linkedinUrl"
+                    id="linkedinUrl"
+                    className="form-control"
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    value={values.linkedinUrl}
+                    required
+                  />
+                  {touched.linkedinUrl
+                    && errors.linkedinUrl
+                    && <FormFeedback style={{ display: 'block' }}>{errors.linkedinUrl}</FormFeedback>}
                 </div>
               </div>
             </fieldset>

--- a/app/js/officers/components/OfficerForm.jsx
+++ b/app/js/officers/components/OfficerForm.jsx
@@ -134,8 +134,8 @@ class OfficerForm extends Component {
           }) => (
             <fieldset className="form-group">
               <div className="form-group row">
-                <label htmlFor="title" className="col-3 col-form-label">Title</label>
-                <div className="col-9">
+                <label htmlFor="title" className="col-4 col-form-label">Title</label>
+                <div className="col-8">
                   <input
                     type="text"
                     name="title"
@@ -152,8 +152,8 @@ class OfficerForm extends Component {
                 </div>
               </div>
               <div className="form-group row">
-                <label htmlFor="email" className="col-3 col-form-label">Email Alias</label>
-                <InputGroup className="col-9">
+                <label htmlFor="email" className="col-4 col-form-label">Email Alias</label>
+                <InputGroup className="col-8">
                   <input
                     type="text"
                     name="email"
@@ -173,8 +173,8 @@ class OfficerForm extends Component {
                 </InputGroup>
               </div>
               <div className="form-group row">
-                <label htmlFor="committeeName" className="col-3 col-form-label">Committee</label>
-                <div className="col-9">
+                <label htmlFor="committeeName" className="col-4 col-form-label">Committee</label>
+                <div className="col-8">
                   <FormikSelectInput
                     name="committeeName"
                     id="committeeName"
@@ -221,8 +221,8 @@ class OfficerForm extends Component {
                 </div>
               </div>
               <div className="form-group row">
-                <label htmlFor="startDate" className="col-3 col-form-label">Start Date</label>
-                <div className="col-9">
+                <label htmlFor="startDate" className="col-4 col-form-label">Start Date</label>
+                <div className="col-8">
                   {/* TODO: Update to use a cross-browser date picker */}
                   <input
                     type="date"
@@ -240,8 +240,8 @@ class OfficerForm extends Component {
                 </div>
               </div>
               <div className="form-group row">
-                <label htmlFor="endDate" className="col-3 col-form-label">End Date</label>
-                <div className="col-9">
+                <label htmlFor="endDate" className="col-4 col-form-label">End Date</label>
+                <div className="col-8">
                   {/* TODO: Update to use a cross-browser date picker */}
                   <input
                     type="date"

--- a/app/js/scoreboard/components/AddMembershipModal.jsx
+++ b/app/js/scoreboard/components/AddMembershipModal.jsx
@@ -85,8 +85,8 @@ class AddMembershipModal extends Component {
           }) => (
             <fieldset className="form-group">
               <div className="form-group row">
-                <label htmlFor="startDate" className="col-3 col-form-label">Start Date</label>
-                <div className="col-9">
+                <label htmlFor="startDate" className="col-4 col-form-label">Start Date</label>
+                <div className="col-8">
                   {/* TODO: Update to use a cross-browser date picker */}
                   <input
                     type="date"
@@ -104,8 +104,8 @@ class AddMembershipModal extends Component {
                 </div>
               </div>
               <div className="form-group row">
-                <label htmlFor="endDate" className="col-3 col-form-label">End Date</label>
-                <div className="col-9">
+                <label htmlFor="endDate" className="col-4 col-form-label">End Date</label>
+                <div className="col-8">
                   {/* TODO: Update to use a cross-browser date picker */}
                   <input
                     type="date"
@@ -123,8 +123,8 @@ class AddMembershipModal extends Component {
                 </div>
               </div>
               <div className="form-group row">
-                <label htmlFor="reason" className="col-3 col-form-label">Reason</label>
-                <div className="col-9">
+                <label htmlFor="reason" className="col-4 col-form-label">Reason</label>
+                <div className="col-8">
                   <textarea
                     name="reason"
                     id="reason"
@@ -141,8 +141,8 @@ class AddMembershipModal extends Component {
                 </div>
               </div>
               <div className="form-group row">
-                <label htmlFor="committeeName" className="col-3 col-form-label">Committee</label>
-                <div className="col-9">
+                <label htmlFor="committeeName" className="col-4 col-form-label">Committee</label>
+                <div className="col-8">
                   <select
                     name="committeeName"
                     id="committeeName"


### PR DESCRIPTION
Adds a field for a LinkedIn URL on the Officer's form. When set, an Officer's profile image becomes a link to their LinkedIn.

Also changes the spacing on the forms so that longer labels don't wrap to a new line.

Finishes: #261

Blocked by: rit-sse/node-api#92