### PR TITLE
Fix /events committee filters and edit/delete icons

### DIFF
--- a/app/js/common/actions/committees.js
+++ b/app/js/common/actions/committees.js
@@ -9,7 +9,7 @@ const loading = utils.createLoading(COMMITTEES);
 export function getCommittees() {
   return (dispatch, getState, { Committees }) => {
     dispatch(loading(GET_COMMITTEES));
-    Committees.all({ active: new Date() }, true)
+    Committees.all({}, true)
       .then(data => dispatch(createAction(GET_COMMITTEES, data)))
       .catch(err => dispatch(createAction(GET_COMMITTEES, err)));
   };

--- a/app/js/common/components/Actions.jsx
+++ b/app/js/common/components/Actions.jsx
@@ -14,10 +14,10 @@ const Actions = ({
     <div className={shown ? 'actions shown' : 'actions'}>
       {children}
       <button className="btn btn-small btn-primary" onClick={editItem}>
-        <i className="fas fa-pencil" aria-hidden="true" />
+        <i className="fas fa-pencil-alt" aria-hidden="true" />
       </button>
       <button className="btn btn-small btn-danger" onClick={deleteItem}>
-        <i className="fas fa-trash-o" aria-hidden="true" />
+        <i className="fas fa-trash" aria-hidden="true" />
       </button>
     </div>
   ) : null

--- a/app/js/events/containers/EventList.js
+++ b/app/js/events/containers/EventList.js
@@ -5,7 +5,7 @@ import { showEventModal } from 'common/actions';
 import { getEvents, destoryEvent } from 'events/actions';
 
 function filterEvents(events, filter) {
-  if (filter.committee && events.all) return events.all.filter(event => event.committeeName === filter.committee.replace(/%20/g, ' '));
+  if (filter.committee) return events.filter(event => event.committeeName === filter.committee.replace(/%20/g, ' '));
   return events;
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     {
       "name": "Bill Dybas",
       "email": "wmdybas@gmail.com"
+    },
+    {
+      "name": "Gavriel Rachael-Homann",
+      "email": "gavrielrachaelhomann@gmail.com"
     }
   ],
   "repository": {


### PR DESCRIPTION
Updates the committees action to no longer specify an "active: <date>" parameter as it was causing duplicate committees to be returned.

Updates the logic for filtering events by committee to no longer check if the events object has an "all" property (which as far as I can tell, doesn't ever exist on the events object, so you can never filter by committee). 

Replaces missing font-awesome icons with existing ones (for editing/deleting events).

Adds my name to the contributors list as it's day 1 and there are plenty of changes to come 😄 