### PR TITLE
Fix filtering by committee and use different icons for edit/delete actions

### DIFF
--- a/app/js/common/components/Actions.jsx
+++ b/app/js/common/components/Actions.jsx
@@ -14,10 +14,10 @@ const Actions = ({
     <div className={shown ? 'actions shown' : 'actions'}>
       {children}
       <button className="btn btn-small btn-primary" onClick={editItem}>
-        <i className="fas fa-pencil" aria-hidden="true" />
+        <i className="fas fa-pencil-alt" aria-hidden="true" />
       </button>
       <button className="btn btn-small btn-danger" onClick={deleteItem}>
-        <i className="fas fa-trash-o" aria-hidden="true" />
+        <i className="fas fa-trash" aria-hidden="true" />
       </button>
     </div>
   ) : null

--- a/app/js/events/containers/EventList.js
+++ b/app/js/events/containers/EventList.js
@@ -5,7 +5,7 @@ import { showEventModal } from 'common/actions';
 import { getEvents, destoryEvent } from 'events/actions';
 
 function filterEvents(events, filter) {
-  if (filter.committee && events.all) return events.all.filter(event => event.committeeName === filter.committee.replace(/%20/g, ' '));
+  if (filter.committee) return events.filter(event => event.committeeName === filter.committee.replace(/%20/g, ' '));
   return events;
 }
 


### PR DESCRIPTION
Updates actions icons to use existing/working font-awesome icons.
Removes logic related to `events.all` from the EventList container as it was causing filtering to not work.