### PR TITLE
Add default end date to memberships

### DIFF
--- a/app/js/scoreboard/components/AddMembershipModal.jsx
+++ b/app/js/scoreboard/components/AddMembershipModal.jsx
@@ -32,11 +32,11 @@ class AddMembershipModal extends Component {
 
     const committeeNames = committees.map(committee => committee.name);
     const dayFormat = 'YYYY-MM-DD';
-    // First day to withdraw classes: Sept 4th or January 22st
+    // Memberships carry over to the first withdrawal date of the following semester
     // Amend these dates as necessary
-    const janDate = moment({ months: 0, day: 22 }).add({ years: 1 });
-    const septDate = moment({ months: 8, day: 4 });
-    const endDate = moment().month() < 8 ? septDate : janDate;
+    const springWithdrawalDate = moment({ months: 0, day: 22 }).add({ years: 1 });
+    const fallWithdrawalDate = moment({ months: 8, day: 4 });
+    const endDate = moment().month() < fallWithdrawalDate.month() ? fallWithdrawalDate : springWithdrawalDate;
 
     return (
       <Modal isOpen={isOpen} toggle={close}>

--- a/app/js/scoreboard/components/AddMembershipModal.jsx
+++ b/app/js/scoreboard/components/AddMembershipModal.jsx
@@ -32,6 +32,11 @@ class AddMembershipModal extends Component {
 
     const committeeNames = committees.map(committee => committee.name);
     const dayFormat = 'YYYY-MM-DD';
+    // First day to withdraw classes: Sept 4th or January 21st
+    // Amend these dates as necessary
+    const janDate = moment({ months: 0, day: 22 });
+    const septDate = moment({ months: 8, day: 4 });
+    const endDate = moment().isAfter(janDate) ? septDate : janDate;
 
     return (
       <Modal isOpen={isOpen} toggle={close}>
@@ -39,7 +44,7 @@ class AddMembershipModal extends Component {
         <UserForm
           initialValues={{
             startDate: moment().format(dayFormat),
-            endDate: '',
+            endDate: endDate.format(dayFormat),
             reason: '',
             committeeName: initialCommitteeName,
           }}

--- a/app/js/scoreboard/components/AddMembershipModal.jsx
+++ b/app/js/scoreboard/components/AddMembershipModal.jsx
@@ -32,11 +32,11 @@ class AddMembershipModal extends Component {
 
     const committeeNames = committees.map(committee => committee.name);
     const dayFormat = 'YYYY-MM-DD';
-    // First day to withdraw classes: Sept 4th or January 21st
+    // First day to withdraw classes: Sept 4th or January 22st
     // Amend these dates as necessary
-    const janDate = moment({ months: 0, day: 22 });
+    const janDate = moment({ months: 0, day: 22 }).add({ years: 1 });
     const septDate = moment({ months: 8, day: 4 });
-    const endDate = moment().isAfter(janDate) ? septDate : janDate;
+    const endDate = moment().month() < 8 ? septDate : janDate;
 
     return (
       <Modal isOpen={isOpen} toggle={close}>


### PR DESCRIPTION
This pre-fills the end date when adding a membership to a (hopefully) sane default.

From what I've seen in the past, memberships typically carry over to the first withdrawal date of the following semester.

This means if I get a membership now (spring 2020), the expiration date should be the fall withdrawal date (9/4/2020), and if I get a membership in the fall, the expiration date should be the following spring withdrawal date (1/22/2021).

I'm pretty bad at conceptualizing time, so please double check my logic on this.
It might also be worth implementing a way of being able to either set, or modify a default for this, that way when dates inevitably change and RIT decides to move starting/ending dates, another PR isn't needed.