### PR TITLE
Add go links to main nav

### DIFF
--- a/app/js/common/components/SSENav.jsx
+++ b/app/js/common/components/SSENav.jsx
@@ -47,6 +47,9 @@ class SSENav extends Component {
             <NavItem>
               <NavLink tag={Link} to="/projects">Projects</NavLink>
             </NavItem>
+            <NavItem>
+              <NavLink tag={Link} to="/go">Go Links</NavLink>  
+            </NavItem> 
             <Dropdown nav isOpen={this.state.opened} toggle={this.toggle}>
               <DropdownToggle nav caret>
                 About


### PR DESCRIPTION
Lindsey said this would be a good idea so I did it. It just adds a link to /go to the main nav so that people who dont know about go links can see them.