### PR TITLE
Reduce signatures for Primary Officer Impeachment to be majority of Active Members

### DIFF
--- a/app/markdown/governing-docs/constitution.md
+++ b/app/markdown/governing-docs/constitution.md
@@ -218,7 +218,7 @@ candidacy requirements for office must resign.
 Primary officers may only be impeached by the completion of a petition started by
 an active member of the Society. The petitioner must provide their reasoning
 for impeachment before receiving signatures.
-Should a petition receive more than one half of the signatures of all active members,
+Should a petition receive a majority of the signatures of all active members,
 it may be presented to the Primary Officers or to the Academic Advisor
 to begin the impeachment process. The Primary Officer in question may not interfere or
 delay this process in any way, nor can they operate in their position during this time.

--- a/app/markdown/governing-docs/constitution.md
+++ b/app/markdown/governing-docs/constitution.md
@@ -218,7 +218,7 @@ candidacy requirements for office must resign.
 Primary officers may only be impeached by the completion of a petition started by
 an active member of the Society. The petitioner must provide their reasoning
 for impeachment before receiving signatures.
-Should a petition receive two thirds of the signatures of all active members,
+Should a petition receive more than one half of the signatures of all active members,
 it may be presented to the Primary Officers or to the Academic Advisor
 to begin the impeachment process. The Primary Officer in question may not interfere or
 delay this process in any way, nor can they operate in their position during this time.


### PR DESCRIPTION
Currently, the Constitution stipulates that in the Primary Officer Impeachment proceedings, an initial petition must receive two thirds signatures of the Active Members. It then says for the Primary to actually be _removed_, you again need two thirds. The margin for petition should be lower than the margin for removal, so I've reduced the margin for petitioning to majority.

I am also open to instead keeping the petition margin to two thirds and increasing the removal margin to three fourths.